### PR TITLE
fix: wrong check caused setting a new texture not to work if not yet loaded

### DIFF
--- a/src/ProjectedMaterial.js
+++ b/src/ProjectedMaterial.js
@@ -31,7 +31,7 @@ export default class ProjectedMaterial extends THREE.MeshPhysicalMaterial {
     this.uniforms.projectedTexture.value = texture
     this.uniforms.isTextureLoaded.value = Boolean(texture.image)
 
-    if (!this.uniforms.isTextureLoaded) {
+    if (!this.uniforms.isTextureLoaded.value) {
       addLoadListener(texture, () => {
         this.uniforms.isTextureLoaded.value = true
 


### PR DESCRIPTION
The missing `.value` was causing that conditional branch to never run, so trying to do the following wasn't working:

```js
material.texture = new TextureLoader.load('foo.jpg') // does not wait for load, causes saveDimensions to result in [1,1]
```

Before this change it required a workaround:

```js
new TextureLoader.load('foo.jpg', tex => {
  material.texture = tex // now it measures dimensions because the image is loaded
})
```