### PR TITLE
dispatch a textureload event when texture load is detected …

### DIFF
--- a/src/ProjectedMaterial.js
+++ b/src/ProjectedMaterial.js
@@ -36,6 +36,7 @@ export default class ProjectedMaterial extends THREE.MeshPhysicalMaterial {
         this.uniforms.isTextureLoaded.value = true
 
         this.#saveDimensions()
+        this.dispatchEvent({ type: 'textureload' })
       })
     } else {
       this.#saveDimensions()
@@ -242,6 +243,7 @@ export default class ProjectedMaterial extends THREE.MeshPhysicalMaterial {
       this.uniforms.isTextureLoaded.value = true
 
       this.#saveDimensions()
+      this.dispatchEvent({ type: 'textureload' })
     })
   }
 


### PR DESCRIPTION
…so people know when to do things (f.e. to re-render a scene).

As an alternative to https://github.com/mrdoob/three.js/pull/24145 which was rejected, this is a less ideal way to signal to users when texture load (in the perspective of ProjectedMaterial) has happened.

Also see the Discussion. Note that using a `TextureLoader.load` callback does not help with the issue described there.

This change allows someone to do the following and for the texture to appear on screen as expected:

```js
// Example 1
const mat = new ProjectedMaterial()

const tex = new TextureLoader.load('foo.png')

mat.texture = tex

mat.addEventListener('textureload', () => {
  renderer.render(scene, camera) // it works.
})
```

Note that the following _does not work_:


```js
// Example 2
const mat = new ProjectedMaterial()

const tex = new TextureLoader.load('foo.png', () => {
  renderer.render(scene, camera) // does *not* work, this will happen before `setInterval` inside of `addLoadListener` detects the texture load, and `this.uniforms.isTextureLoaded` is still `false` when this line runs.
})

mat.texture = tex
```

---

As an alternative to this PR, we could add a new `isTextureLoaded` getter/setter. If we do this instead, then the following will be a working alternative:


```js
// Example 3
const mat = new ProjectedMaterial()

const tex = new TextureLoader.load('foo.png', () => {
  mat.isTextureLoaded = true // calls saveDimensions too.
  renderer.render(scene, camera) // now it works
})

mat.texture = tex
```

Which one do you like better? Example 1, or Example 3?

I like the method in Example 1 better because it does not present the user with an opportunity to do things wrong, whereas with the method in Example 3 the user can forget to set `isTextureLoaded` or they can set it at the wrong time before the texture is actually loaded.

---

To be honest, the cleanest solution would be if https://github.com/mrdoob/three.js/pull/24145 was approved, in which case the example 2 above would work fine.

```js
// Example 4, same as Example 2 but with updated comment
const mat = new ProjectedMaterial()

const tex = new TextureLoader.load('foo.png', () => {
  renderer.render(scene, camera) // now it works, because ProjectedMaterial would use texture load event instead of addLoadListener
})

mat.texture = tex
```