### PR TITLE
Update ProjectedMaterial.js

### DIFF
--- a/src/ProjectedMaterial.js
+++ b/src/ProjectedMaterial.js
@@ -305,7 +305,7 @@ export default class ProjectedMaterial extends THREE.MeshPhysicalMaterial {
     this.uniforms.viewMatrixCamera.value.copy(viewMatrixCamera)
     this.uniforms.projectionMatrixCamera.value.copy(projectionMatrixCamera)
     this.uniforms.projPosition.value.setFromMatrixPosition(modelMatrixCamera)
-    this.uniforms.projDirection.value.set(0, 0, 1).applyMatrix4(modelMatrixCamera)
+    this.uniforms.projDirection.value.set(0, 0, 1).transformDirection(modelMatrixCamera)
 
     // tell the shader we've projected
     this.uniforms.isTextureProjected.value = true


### PR DESCRIPTION
Fix projection direction of the camera when camera translate. 
I had an issue with a camera I was translating but always facing down. and some faces of the object I was projecting to were not projected to due to "isFacingProjector" in shader.
This was because this.uniforms.projDirection should not take into account the translation of the camera.